### PR TITLE
ランキングAPIの仕様変更

### DIFF
--- a/app/Http/Controllers/Api/PlayerRanking.php
+++ b/app/Http/Controllers/Api/PlayerRanking.php
@@ -55,11 +55,13 @@ class PlayerRanking extends Controller
         $offset = (int) $request->input("offset") ?: self::DEFAULT_OFFSET_VALUE;
         $offset = max(0, $offset);
 
-        $ranks = $this->fetchRankingResolver($ranking_type)->getRanking($limit, $offset);
+        $entire_ranking = $this->fetchRankingResolver($ranking_type)->getRanking();
+        $sub_ranking = array_slice($entire_ranking, $offset, $limit);
 
         return response()->json([
-            'result_count' => count($ranks),
-            'ranks' => $ranks
+            'result_count' => count($sub_ranking),
+            'ranks' => $sub_ranking,
+            'total-ranked-player' => count($entire_ranking)
         ]);
     }
 

--- a/app/Http/Controllers/Api/PlayerRanking.php
+++ b/app/Http/Controllers/Api/PlayerRanking.php
@@ -14,7 +14,7 @@ class PlayerRanking extends Controller
     const DEFAULT_LIMIT_VALUE = 100;
     const LIMIT_MAX = 100;
 
-    const DEFAULT_OFFSET_VALUE = 1;
+    const DEFAULT_OFFSET_VALUE = 0;
 
     const DEFAULT_RANKING_TYPES = "break,build,playtime,vote";
 
@@ -53,7 +53,7 @@ class PlayerRanking extends Controller
         $limit = max(1, min($limit, self::LIMIT_MAX));
 
         $offset = (int) $request->input("offset") ?: self::DEFAULT_OFFSET_VALUE;
-        $offset = max(1, $offset);
+        $offset = max(0, $offset);
 
         $ranks = $this->fetchRankingResolver($ranking_type)->getRanking($limit, $offset);
 

--- a/app/Http/Controllers/Api/PlayerRanking/RankingResolver.php
+++ b/app/Http/Controllers/Api/PlayerRanking/RankingResolver.php
@@ -47,7 +47,7 @@ abstract class RankingResolver
             $ranked_players[] = $this->toPlayerRank($player);
         }
 
-        return array_slice($ranked_players, $offset - 1, $limit);
+        return array_slice($ranked_players, $offset, $limit);
     }
 
     public function getPlayerRank($player_uuid)

--- a/app/Http/Controllers/Api/PlayerRanking/RankingResolver.php
+++ b/app/Http/Controllers/Api/PlayerRanking/RankingResolver.php
@@ -25,7 +25,11 @@ abstract class RankingResolver
         ];
     }
 
-    public function getRanking($limit, $offset)
+    /**
+     * ランキング全体を取得する。
+     * @return array IPlayerRankの配列
+     */
+    public function getRanking()
     {
         $comparator = $this->getRankComparator();
 
@@ -47,9 +51,14 @@ abstract class RankingResolver
             $ranked_players[] = $this->toPlayerRank($player);
         }
 
-        return array_slice($ranked_players, $offset, $limit);
+        return $ranked_players;
     }
 
+    /**
+     * 指定プレーヤーの順位を取得する
+     * @param $player_uuid string プレーヤーのUUID
+     * @return array|null IPlayerRankの配列/プレーヤーの順位が存在しない場合はnull
+     */
     public function getPlayerRank($player_uuid)
     {
         $comparator = $this->getRankComparator();


### PR DESCRIPTION
以下の仕様に変更を加えました：
* 戻り値にランキング全体のプレーヤー数を表す`total-ranked-player`(整数型)を追加
* `GET`パラメータの`offset`の定義を```結果の順位の非包括的な下限(0以上)、デフォルトで0```に変更