### PR TITLE
プレーヤーデータAPIの修正

### DIFF
--- a/app/Http/Controllers/Api/PlayerData.php
+++ b/app/Http/Controllers/Api/PlayerData.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Api\PlayerData\BreakPlayerDataResolver;
 use App\Http\Controllers\Api\PlayerData\BuildPlayerDataResolver;
+use App\Http\Controllers\Api\PlayerData\LastQuitPlayerDataResolver;
 use App\Http\Controllers\Api\PlayerData\PlaytimePlayerDataResolver;
 use App\Http\Controllers\Api\PlayerData\VotePlayerDataResolver;
 use App\Http\Controllers\Controller;
@@ -24,7 +25,8 @@ class PlayerData extends Controller
             "break" => new BreakPlayerDataResolver(),
             "build" => new BuildPlayerDataResolver(),
             "playtime" => new PlaytimePlayerDataResolver(),
-            "vote" => new VotePlayerDataResolver()
+            "vote" => new VotePlayerDataResolver(),
+            "lastquit" => new LastQuitPlayerDataResolver()
         ];
     }
 

--- a/app/Http/Controllers/Api/PlayerData.php
+++ b/app/Http/Controllers/Api/PlayerData.php
@@ -45,7 +45,7 @@ class PlayerData extends Controller
         $data = $this->resolvers[$data_type]->resolveData($player_uuid);
 
         // データが見つからなかった場合
-        if ($data == null) {
+        if ($data === null) {
             return response()->json(["message" => "requested record does not exist."], 404);
         }
 

--- a/app/Http/Controllers/Api/PlayerData/LastQuitPlayerDataResolver.php
+++ b/app/Http/Controllers/Api/PlayerData/LastQuitPlayerDataResolver.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Kory
+ * Date: 9/15/2017
+ * Time: 12:15 PM
+ */
+
+namespace App\Http\Controllers\Api\PlayerData;
+
+class LastQuitPlayerDataResolver extends RawPlayerDataResolver
+{
+    /**
+     * @return string DB内でデータに対応するカラムの名前
+     */
+    function getDataColumnName()
+    {
+        return "lastquit";
+    }
+}

--- a/app/Http/Controllers/Api/PlayerData/LastQuitPlayerDataResolver.php
+++ b/app/Http/Controllers/Api/PlayerData/LastQuitPlayerDataResolver.php
@@ -1,13 +1,11 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: Kory
- * Date: 9/15/2017
- * Time: 12:15 PM
- */
 
 namespace App\Http\Controllers\Api\PlayerData;
 
+/**
+ * 最終ログアウト時間のリゾルバクラス
+ * @package App\Http\Controllers\Api\PlayerData
+ */
 class LastQuitPlayerDataResolver extends RawPlayerDataResolver
 {
     /**

--- a/app/Http/Controllers/Api/PlayerData/PlaytimePlayerDataResolver.php
+++ b/app/Http/Controllers/Api/PlayerData/PlaytimePlayerDataResolver.php
@@ -35,7 +35,7 @@ class PlaytimePlayerDataResolver extends PlayerDataResolver
     {
         $raw_data = $this->fetchRawData($player_uuid);
 
-        if ($raw_data == null) {
+        if ($raw_data === null) {
             return null;
         }
 

--- a/app/Http/Controllers/Api/PlayerData/RawPlayerDataResolver.php
+++ b/app/Http/Controllers/Api/PlayerData/RawPlayerDataResolver.php
@@ -12,7 +12,7 @@ abstract class RawPlayerDataResolver extends PlayerDataResolver
     {
         $raw_data = $this->fetchRawData($player_uuid);
 
-        if ($raw_data == null) {
+        if ($raw_data === null) {
             return null;
         }
 


### PR DESCRIPTION
以下の点を修正しました：
 * プレーヤーデータAPIにて、カラムの値が0だった場合に404が返される現象を修正
 * `/api/players/{player.uuid}/lastquit` を実装