### PR TITLE
メンテナンス画面の実装＋スマホ用viewport設定を追加

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -50,8 +50,11 @@ class Handler extends ExceptionHandler
                 return response()->view('errors', ['message' => '403 このページはアクセスが制限されています。']);
             }
             // 404
-            if($exception->getStatusCode() == 404) {
+            elseif($exception->getStatusCode() == 404) {
                 return response()->view('errors', ['message' => '404 該当のページは存在しません。']);
+            }
+            elseif ($exception->getStatusCode() == 503) {
+                return response()->view('errors', ['message' => "現在、整地ランキングはメンテナンス中です。"]);
             }
             // 500
             return response()->view('errors', ['message' => '500 internal server error']);

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -53,11 +53,14 @@ class Handler extends ExceptionHandler
             elseif($exception->getStatusCode() == 404) {
                 return response()->view('errors', ['message' => '404 該当のページは存在しません。']);
             }
+            // 500
+            elseif ($exception->getStatusCode() == 500) {
+                return response()->view('errors', ['message' => '500 internal server error']);
+            }
+            // 503 (メンテナンス)
             elseif ($exception->getStatusCode() == 503) {
                 return response()->view('errors', ['message' => "現在、整地ランキングはメンテナンス中です。"]);
             }
-            // 500
-            return response()->view('errors', ['message' => '500 internal server error']);
         }
         return parent::render($request, $exception);
     }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -18,6 +18,7 @@ class Kernel extends HttpKernel
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+        \App\Http\Middleware\CheckForMaintenanceMode::class,
     ];
 
     /**

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -14,11 +14,10 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $middleware = [
-        \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
+        \App\Http\Middleware\CheckForMaintenanceMode::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
-        \App\Http\Middleware\CheckForMaintenanceMode::class,
     ];
 
     /**

--- a/app/Http/Middleware/CheckForMaintenanceMode.php
+++ b/app/Http/Middleware/CheckForMaintenanceMode.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Contracts\Foundation\Application;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class CheckForMaintenanceMode
+{
+    /**
+     * The application implementation.
+     *
+     * @var \Illuminate\Contracts\Foundation\Application
+     */
+    protected $app;
+    /**
+     * Create a new middleware instance.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @return void
+     */
+    public function __construct(Application $app)
+    {
+        $this->app = $app;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        $allow = explode(',', env('MAINTENANCE_IP'));
+
+        if ($this->app->isDownForMaintenance()) {
+            if (!in_array($request->getClientIp(), $allow)) {
+                throw new HttpException(503);
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -5,6 +5,7 @@
 
     <meta charset="UTF-8">
     <meta name="csrf-token" content="{{ csrf_token() }}" />
+    <meta name="viewport" content="width=device-width,initial-scale=1">
 
     <script src="{{asset('/js/base/jquery-3.1.1.min.js?'.date('Ymd'))}}"></script>
     <script src="{{asset('/js/base/bootstrap.min.js?'.date('Ymd'))}}"></script>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
 
     <!-- CSRF Token -->
     <meta name="csrf-token" content="{{ csrf_token() }}">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -55,7 +55,7 @@
                     <ul class="nav navbar-nav navbar-right">
                         <!-- Authentication Links -->
                         @if (empty($user['preferred_username']))
-                            <li><a href="/login/">ログイン</a></li>
+                            <li><a href="/login/jms">ログイン</a></li>
                             {{--<li><a href="{{ route('register') }}">Register</a></li>--}}
                         @else
                             <li class="dropdown">


### PR DESCRIPTION
Koryさんに実装いただいた、React.jsを利用した非同期ランキングの本番実装に利用するため、
Laravel標準で備わっているメンテナンス機能の設定を追加しました。

また、スマートフォンからアクセスした際、今まではPC用ビューになっていましたが、
viewportを正しく設定し、スマホでも適切なレイアウトになるように設定を追記しました。