### PR TITLE
各種ランキングの実装

### DIFF
--- a/app/Console/Commands/CountDailyRanking.php
+++ b/app/Console/Commands/CountDailyRanking.php
@@ -32,12 +32,17 @@ class CountDailyRanking extends CountRanking
     {
         foreach ($target_data as $player_data) {
             // カウント用テーブルのデータ有無を確認
+            $player = DailyRankingTable::where('uuid', $player_data->uuid)->first();
+            // 期間内のデータが存在するかを確認
             $today_data = DailyRankingTable::where('uuid', $player_data->uuid)
                 ->where('count_date', Carbon::now()->format('Y-m-d'))->first();
 
-            if (empty($today_data)) {
+            if (empty($player)) {
                 // カウント用テーブルに比較用の初期データを登録
                 parent::registerInitialData(new DailyRankingTable(), $player_data);
+            } else if (empty($today_data)){
+                // 比較用の初期データを更新
+                parent::registerInitialData($player, $player_data);
             } else {
                 // 初期データとの差分を記録
                 parent::registerDiffData($today_data, $player_data);

--- a/app/Console/Commands/CountDailyRanking.php
+++ b/app/Console/Commands/CountDailyRanking.php
@@ -6,7 +6,7 @@ use App\DailyRankingTable;
 use App\PlayerData;
 use Carbon\Carbon;
 
-class CountDailyRanking
+class CountDailyRanking extends CountRanking
 {
     /**
      * Execute the console command.
@@ -38,30 +38,10 @@ class CountDailyRanking
             if (empty($today_data)) {
                 // カウント用テーブルに比較用の初期データを登録
                 $daily_ranking_table = new DailyRankingTable();
-                $daily_ranking_table->count_date = Carbon::now();   // datetime
-                $daily_ranking_table->name = $player_data->name;    // varchar(30)
-                $daily_ranking_table->uuid = $player_data->uuid;    // varchar(128)
-                $daily_ranking_table->previous_break_count = $player_data->totalbreaknum;   // bigint(20)
-                $daily_ranking_table->previous_build_count = $player_data->build_count;     // int(11)
-                $daily_ranking_table->previous_vote_count = $player_data->p_vote;           // int(11)
-                $daily_ranking_table->previous_playtick_count = $player_data->playtick;     // int(11)
-                $daily_ranking_table->save();
+                parent::savePreviousData($daily_ranking_table, $player_data);
             } else {
                 // 整地量
-                $diff_break = $player_data->totalbreaknum - $today_data->previous_break_count;
-                $today_data->break_count= $diff_break;
-
-                // 建築量
-                $diff_build = $player_data->build_count - $today_data->previous_build_count;
-                $today_data->build_count= $diff_build;
-
-                $diff_tick = $player_data->playtick - $today_data->previous_playtick_count;
-                $today_data->playtick_count = $diff_tick;
-
-                // 投票数
-                $today_data->vote_count= $player_data->p_vote;
-
-                $today_data->save();
+                parent::saveDiffData($today_data, $player_data);
             }
         }
     }

--- a/app/Console/Commands/CountDailyRanking.php
+++ b/app/Console/Commands/CountDailyRanking.php
@@ -16,7 +16,7 @@ class CountDailyRanking extends CountRanking
     {
         logger('>>>>  デイリーランキングバッチ：処理開始 >>>>');
 
-        // 24時間以内にログインしたユーザのデータを取得する
+        // 24時間以内にログインしたユーザを更新対象にする
         $target_data = PlayerData::where('lastquit', '>', Carbon::yesterday())->get();
         logger('処理対象件数：'.count($target_data));
         $this->countRanking($target_data);
@@ -37,11 +37,10 @@ class CountDailyRanking extends CountRanking
 
             if (empty($today_data)) {
                 // カウント用テーブルに比較用の初期データを登録
-                $daily_ranking_table = new DailyRankingTable();
-                parent::savePreviousData($daily_ranking_table, $player_data);
+                parent::registerInitialData(new DailyRankingTable(), $player_data);
             } else {
-                // 整地量
-                parent::saveDiffData($today_data, $player_data);
+                // 初期データとの差分を記録
+                parent::registerDiffData($today_data, $player_data);
             }
         }
     }

--- a/app/Console/Commands/CountDailyRanking.php
+++ b/app/Console/Commands/CountDailyRanking.php
@@ -5,34 +5,9 @@ namespace App\Console\Commands;
 use App\DailyRankingTable;
 use App\PlayerData;
 use Carbon\Carbon;
-use Illuminate\Console\Command;
 
-class CountDailyRanking extends Command
+class CountDailyRanking
 {
-    /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
-    protected $signature = 'ranking:count {type=daily}';
-
-    /**
-     * The console command description.
-     *
-     * @var string
-     */
-    protected $description = 'Web整地ランキングのカウント用バッチ';
-
-    /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
     /**
      * Execute the console command.
      *
@@ -63,13 +38,13 @@ class CountDailyRanking extends Command
             if (empty($today_data)) {
                 // カウント用テーブルに比較用の初期データを登録
                 $daily_ranking_table = new DailyRankingTable();
-                $daily_ranking_table->count_date = Carbon::now();
-                $daily_ranking_table->name = $player_data->name;
-                $daily_ranking_table->uuid = $player_data->uuid;
-                $daily_ranking_table->previous_break_count = $player_data->totalbreaknum;
-                $daily_ranking_table->previous_build_count = $player_data->build_count;
-                $daily_ranking_table->previous_vote_count = $player_data->p_vote;
-                $daily_ranking_table->previous_playtick_count = $player_data->playtick;
+                $daily_ranking_table->count_date = Carbon::now();   // datetime
+                $daily_ranking_table->name = $player_data->name;    // varchar(30)
+                $daily_ranking_table->uuid = $player_data->uuid;    // varchar(128)
+                $daily_ranking_table->previous_break_count = $player_data->totalbreaknum;   // bigint(20)
+                $daily_ranking_table->previous_build_count = $player_data->build_count;     // int(11)
+                $daily_ranking_table->previous_vote_count = $player_data->p_vote;           // int(11)
+                $daily_ranking_table->previous_playtick_count = $player_data->playtick;     // int(11)
                 $daily_ranking_table->save();
             } else {
                 // 整地量
@@ -79,6 +54,9 @@ class CountDailyRanking extends Command
                 // 建築量
                 $diff_build = $player_data->build_count - $today_data->previous_build_count;
                 $today_data->build_count= $diff_build;
+
+                $diff_tick = $player_data->playtick - $today_data->previous_playtick_count;
+                $today_data->playtick_count = $diff_tick;
 
                 // 投票数
                 $today_data->vote_count= $player_data->p_vote;

--- a/app/Console/Commands/CountMonthlyRanking.php
+++ b/app/Console/Commands/CountMonthlyRanking.php
@@ -36,10 +36,10 @@ class CountMonthlyRanking extends Command
     {
         foreach ($target_data as $player_data) {
             // カウント用テーブルのデータ有無を確認
-            $today_data = MonthlyRankingTable::where('uuid', $player_data->uuid)
+            $month_data = MonthlyRankingTable::where('uuid', $player_data->uuid)
                 ->whereMonth('count_date', Carbon::now()->month)->first();
 
-            if (empty($today_data)) {
+            if (empty($month_data)) {
                 // カウント用テーブルに比較用の初期データを登録
                 $monthly_ranking_table = new MonthlyRankingTable();
                 $monthly_ranking_table->count_date = Carbon::now();   // datetime
@@ -52,20 +52,20 @@ class CountMonthlyRanking extends Command
                 $monthly_ranking_table->save();
             } else {
                 // 整地量
-                $diff_break = $player_data->totalbreaknum - $today_data->previous_break_count;
-                $today_data->break_count= $diff_break;
+                $diff_break = $player_data->totalbreaknum - $month_data->previous_break_count;
+                $month_data->break_count= $diff_break;
 
                 // 建築量
-                $diff_build = $player_data->build_count - $today_data->previous_build_count;
-                $today_data->build_count= $diff_build;
+                $diff_build = $player_data->build_count - $month_data->previous_build_count;
+                $month_data->build_count= $diff_build;
 
-                $diff_tick = $player_data->playtick - $today_data->previous_playtick_count;
-                $today_data->playtick_count = $diff_tick;
+                $diff_tick = $player_data->playtick - $month_data->previous_playtick_count;
+                $month_data->playtick_count = $diff_tick;
 
                 // 投票数
-                $today_data->vote_count= $player_data->p_vote;
+                $month_data->vote_count= $player_data->p_vote;
 
-                $today_data->save();
+                $month_data->save();
             }
         }
     }

--- a/app/Console/Commands/CountMonthlyRanking.php
+++ b/app/Console/Commands/CountMonthlyRanking.php
@@ -1,0 +1,72 @@
+<?php
+
+
+namespace App\Console\Commands;
+
+
+use App\MonthlyRankingTable;
+use App\PlayerData;
+use Carbon\Carbon;
+
+use Illuminate\Console\Command;
+
+class CountMonthlyRanking extends Command
+{
+    /**
+     * Execute the console command.
+     *
+     */
+    public function handle()
+    {
+        logger('>>>>  マンスリーランキングバッチ：処理開始 >>>>');
+
+        // 今月にログインしたユーザのデータを取得する
+        $target_data = PlayerData::whereMonth('lastquit', Carbon::now()->month)->get();
+        logger('処理対象件数：' . count($target_data));
+        $this->countRanking($target_data);
+
+        logger('<<<<  マンスリーランキングバッチ：処理終了 <<<<');
+    }
+
+    /**
+     * ランキングデータのカウント＋保存
+     * @param $target_data
+     */
+    private function countRanking($target_data)
+    {
+        foreach ($target_data as $player_data) {
+            // カウント用テーブルのデータ有無を確認
+            $today_data = MonthlyRankingTable::where('uuid', $player_data->uuid)
+                ->whereMonth('count_date', Carbon::now()->month)->first();
+
+            if (empty($today_data)) {
+                // カウント用テーブルに比較用の初期データを登録
+                $monthly_ranking_table = new MonthlyRankingTable();
+                $monthly_ranking_table->count_date = Carbon::now();   // datetime
+                $monthly_ranking_table->name = $player_data->name;    // varchar(30)
+                $monthly_ranking_table->uuid = $player_data->uuid;    // varchar(128)
+                $monthly_ranking_table->previous_break_count = $player_data->totalbreaknum;   // bigint(20)
+                $monthly_ranking_table->previous_build_count = $player_data->build_count;     // int(11)
+                $monthly_ranking_table->previous_vote_count = $player_data->p_vote;           // int(11)
+                $monthly_ranking_table->previous_playtick_count = $player_data->playtick;     // int(11)
+                $monthly_ranking_table->save();
+            } else {
+                // 整地量
+                $diff_break = $player_data->totalbreaknum - $today_data->previous_break_count;
+                $today_data->break_count= $diff_break;
+
+                // 建築量
+                $diff_build = $player_data->build_count - $today_data->previous_build_count;
+                $today_data->build_count= $diff_build;
+
+                $diff_tick = $player_data->playtick - $today_data->previous_playtick_count;
+                $today_data->playtick_count = $diff_tick;
+
+                // 投票数
+                $today_data->vote_count= $player_data->p_vote;
+
+                $today_data->save();
+            }
+        }
+    }
+}

--- a/app/Console/Commands/CountMonthlyRanking.php
+++ b/app/Console/Commands/CountMonthlyRanking.php
@@ -16,7 +16,7 @@ class CountMonthlyRanking extends CountRanking
     {
         logger('>>>>  マンスリーランキングバッチ：処理開始 >>>>');
 
-        // 24時間以内にログインしたユーザのデータを取得する
+        // 24時間以内にログインしたユーザを更新対象にする
         $target_data = PlayerData::where('lastquit', '>', Carbon::yesterday())->get();
         logger('処理対象件数：' . count($target_data));
         $this->countRanking($target_data);
@@ -38,10 +38,10 @@ class CountMonthlyRanking extends CountRanking
 
             if (empty($month_data)) {
                 // カウント用テーブルに比較用の初期データを登録
-                $monthly_ranking_table = new MonthlyRankingTable();
-                parent::savePreviousData($monthly_ranking_table, $player_data);
+                parent::registerInitialData(new MonthlyRankingTable(), $player_data);
             } else {
-                parent::saveDiffData($month_data, $player_data);
+                // 初期データとの差分を記録
+                parent::registerDiffData($month_data, $player_data);
             }
         }
     }

--- a/app/Console/Commands/CountMonthlyRanking.php
+++ b/app/Console/Commands/CountMonthlyRanking.php
@@ -20,8 +20,8 @@ class CountMonthlyRanking extends Command
     {
         logger('>>>>  マンスリーランキングバッチ：処理開始 >>>>');
 
-        // 今月にログインしたユーザのデータを取得する
-        $target_data = PlayerData::whereMonth('lastquit', Carbon::now()->month)->get();
+        // 24時間以内にログインしたユーザのデータを取得する
+        $target_data = PlayerData::where('lastquit', '>', Carbon::yesterday())->get();
         logger('処理対象件数：' . count($target_data));
         $this->countRanking($target_data);
 

--- a/app/Console/Commands/CountMonthlyRanking.php
+++ b/app/Console/Commands/CountMonthlyRanking.php
@@ -32,13 +32,18 @@ class CountMonthlyRanking extends CountRanking
     {
         foreach ($target_data as $player_data) {
             // カウント用テーブルのデータ有無を確認
+            $player = MonthlyRankingTable::where('uuid', $player_data->uuid)->first();
+            // 期間内のデータが存在するかを確認
             $month_data = MonthlyRankingTable::where('uuid', $player_data->uuid)
                 ->whereYear('count_date', Carbon::now()->year)
                 ->whereMonth('count_date', Carbon::now()->month)->first();
 
-            if (empty($month_data)) {
+            if (empty($player)) {
                 // カウント用テーブルに比較用の初期データを登録
                 parent::registerInitialData(new MonthlyRankingTable(), $player_data);
+            } else if (empty($month_data)){
+                // 比較用の初期データを更新
+                parent::registerInitialData($player, $player_data);
             } else {
                 // 初期データとの差分を記録
                 parent::registerDiffData($month_data, $player_data);

--- a/app/Console/Commands/CountMonthlyRanking.php
+++ b/app/Console/Commands/CountMonthlyRanking.php
@@ -37,6 +37,7 @@ class CountMonthlyRanking extends Command
         foreach ($target_data as $player_data) {
             // カウント用テーブルのデータ有無を確認
             $month_data = MonthlyRankingTable::where('uuid', $player_data->uuid)
+                ->whereYear('count_date', Carbon::now()->year)
                 ->whereMonth('count_date', Carbon::now()->month)->first();
 
             if (empty($month_data)) {

--- a/app/Console/Commands/CountMonthlyRanking.php
+++ b/app/Console/Commands/CountMonthlyRanking.php
@@ -1,16 +1,12 @@
 <?php
 
-
 namespace App\Console\Commands;
-
 
 use App\MonthlyRankingTable;
 use App\PlayerData;
 use Carbon\Carbon;
 
-use Illuminate\Console\Command;
-
-class CountMonthlyRanking extends Command
+class CountMonthlyRanking
 {
     /**
      * Execute the console command.

--- a/app/Console/Commands/CountMonthlyRanking.php
+++ b/app/Console/Commands/CountMonthlyRanking.php
@@ -6,7 +6,7 @@ use App\MonthlyRankingTable;
 use App\PlayerData;
 use Carbon\Carbon;
 
-class CountMonthlyRanking
+class CountMonthlyRanking extends CountRanking
 {
     /**
      * Execute the console command.
@@ -39,30 +39,9 @@ class CountMonthlyRanking
             if (empty($month_data)) {
                 // カウント用テーブルに比較用の初期データを登録
                 $monthly_ranking_table = new MonthlyRankingTable();
-                $monthly_ranking_table->count_date = Carbon::now();   // datetime
-                $monthly_ranking_table->name = $player_data->name;    // varchar(30)
-                $monthly_ranking_table->uuid = $player_data->uuid;    // varchar(128)
-                $monthly_ranking_table->previous_break_count = $player_data->totalbreaknum;   // bigint(20)
-                $monthly_ranking_table->previous_build_count = $player_data->build_count;     // int(11)
-                $monthly_ranking_table->previous_vote_count = $player_data->p_vote;           // int(11)
-                $monthly_ranking_table->previous_playtick_count = $player_data->playtick;     // int(11)
-                $monthly_ranking_table->save();
+                parent::savePreviousData($monthly_ranking_table, $player_data);
             } else {
-                // 整地量
-                $diff_break = $player_data->totalbreaknum - $month_data->previous_break_count;
-                $month_data->break_count= $diff_break;
-
-                // 建築量
-                $diff_build = $player_data->build_count - $month_data->previous_build_count;
-                $month_data->build_count= $diff_build;
-
-                $diff_tick = $player_data->playtick - $month_data->previous_playtick_count;
-                $month_data->playtick_count = $diff_tick;
-
-                // 投票数
-                $month_data->vote_count= $player_data->p_vote;
-
-                $month_data->save();
+                parent::saveDiffData($month_data, $player_data);
             }
         }
     }

--- a/app/Console/Commands/CountRanking.php
+++ b/app/Console/Commands/CountRanking.php
@@ -34,6 +34,9 @@ abstract class CountRanking
      * @param $player_data: 現在のプレイヤデータ
      */
     protected function registerDiffData($ranking_table, $player_data){
+        // 名前の更新
+        $ranking_table->name = $player_data->name;
+
         // 整地量
         $diff_break = $player_data->totalbreaknum - $ranking_table->previous_break_count;
         $ranking_table->break_count= $diff_break;

--- a/app/Console/Commands/CountRanking.php
+++ b/app/Console/Commands/CountRanking.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class CountRanking extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'ranking:count {type=daily : 期間を指定}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Web整地ランキングのカウント用バッチ';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     */
+    public function handle()
+    {
+        $type = $this->argument('type');
+
+        switch ($type) {
+            case 'daily':
+                (new CountDailyRanking())->handle();
+                break;
+            case 'weekly':
+                (new CountWeeklyRanking())->handle();
+                break;
+            case 'monthly':
+                (new CountMonthlyRanking())->handle();
+                break;
+            //case 'yearly':
+            //  break;
+            default:
+        }
+    }
+}

--- a/app/Console/Commands/CountRanking.php
+++ b/app/Console/Commands/CountRanking.php
@@ -21,6 +21,10 @@ abstract class CountRanking
         $ranking_table->previous_build_count = $player_data->build_count;     // int(11)
         $ranking_table->previous_vote_count = $player_data->p_vote;           // int(11)
         $ranking_table->previous_playtick_count = $player_data->playtick;     // int(11)
+        $ranking_table->break_count = 0;
+        $ranking_table->build_count = 0;
+        $ranking_table->playtick_count = 0;
+        $ranking_table->vote_count = 0;
         $ranking_table->save();
     }
     

--- a/app/Console/Commands/CountRanking.php
+++ b/app/Console/Commands/CountRanking.php
@@ -8,7 +8,12 @@ abstract class CountRanking
 {
     abstract public function handle();
 
-    protected function savePreviousData($ranking_table, $player_data){
+    /**
+     * 対象ランキングテーブルにカウント用テーブルに比較用の初期データを登録する
+     * @param $ranking_table: 対象ランキングテーブル
+     * @param $player_data: 現在のプレイヤデータ
+     */
+    protected function registerInitialData($ranking_table, $player_data){
         $ranking_table->count_date = Carbon::now();   // datetime
         $ranking_table->name = $player_data->name;    // varchar(30)
         $ranking_table->uuid = $player_data->uuid;    // varchar(128)
@@ -18,21 +23,27 @@ abstract class CountRanking
         $ranking_table->previous_playtick_count = $player_data->playtick;     // int(11)
         $ranking_table->save();
     }
-
-    protected function saveDiffData($ranking_data, $player_data){
-        $diff_break = $player_data->totalbreaknum - $ranking_data->previous_break_count;
-        $ranking_data->break_count= $diff_break;
+    
+    /**
+     * 対象ランキングテーブルに初期データと現在のデータの差分を記録
+     * @param $ranking_table: 対象ランキングテーブル
+     * @param $player_data: 現在のプレイヤデータ
+     */
+    protected function registerDiffData($ranking_table, $player_data){
+        // 整地量
+        $diff_break = $player_data->totalbreaknum - $ranking_table->previous_break_count;
+        $ranking_table->break_count= $diff_break;
 
         // 建築量
-        $diff_build = $player_data->build_count - $ranking_data->previous_build_count;
-        $ranking_data->build_count= $diff_build;
+        $diff_build = $player_data->build_count - $ranking_table->previous_build_count;
+        $ranking_table->build_count= $diff_build;
 
-        $diff_tick = $player_data->playtick - $ranking_data->previous_playtick_count;
-        $ranking_data->playtick_count = $diff_tick;
+        $diff_tick = $player_data->playtick - $ranking_table->previous_playtick_count;
+        $ranking_table->playtick_count = $diff_tick;
 
         // 投票数
-        $ranking_data->vote_count= $player_data->p_vote;
+        $ranking_table->vote_count= $player_data->p_vote;
 
-        $ranking_data->save();
+        $ranking_table->save();
     }
 }

--- a/app/Console/Commands/CountRanking.php
+++ b/app/Console/Commands/CountRanking.php
@@ -9,7 +9,7 @@ abstract class CountRanking
     abstract public function handle();
 
     /**
-     * 対象ランキングテーブルにカウント用テーブルに比較用の初期データを登録する
+     * 対象ランキングテーブルに比較用の初期データを登録する
      * @param $ranking_table: 対象ランキングテーブル
      * @param $player_data: 現在のプレイヤデータ
      */

--- a/app/Console/Commands/CountRanking.php
+++ b/app/Console/Commands/CountRanking.php
@@ -48,8 +48,9 @@ class CountRanking extends Command
             case 'monthly':
                 (new CountMonthlyRanking())->handle();
                 break;
-            //case 'yearly':
-            //  break;
+            case 'yearly':
+                (new CountYearlyRanking())->handle();
+                break;
             default:
         }
     }

--- a/app/Console/Commands/CountRanking.php
+++ b/app/Console/Commands/CountRanking.php
@@ -8,15 +8,15 @@ abstract class CountRanking
 {
     abstract public function handle();
 
-    protected function savePreviousData($table, $player_data){
-        $table->count_date = Carbon::now();   // datetime
-        $table->name = $player_data->name;    // varchar(30)
-        $table->uuid = $player_data->uuid;    // varchar(128)
-        $table->previous_break_count = $player_data->totalbreaknum;   // bigint(20)
-        $table->previous_build_count = $player_data->build_count;     // int(11)
-        $table->previous_vote_count = $player_data->p_vote;           // int(11)
-        $table->previous_playtick_count = $player_data->playtick;     // int(11)
-        $table->save();
+    protected function savePreviousData($ranking_table, $player_data){
+        $ranking_table->count_date = Carbon::now();   // datetime
+        $ranking_table->name = $player_data->name;    // varchar(30)
+        $ranking_table->uuid = $player_data->uuid;    // varchar(128)
+        $ranking_table->previous_break_count = $player_data->totalbreaknum;   // bigint(20)
+        $ranking_table->previous_build_count = $player_data->build_count;     // int(11)
+        $ranking_table->previous_vote_count = $player_data->p_vote;           // int(11)
+        $ranking_table->previous_playtick_count = $player_data->playtick;     // int(11)
+        $ranking_table->save();
     }
 
     protected function saveDiffData($ranking_data, $player_data){

--- a/app/Console/Commands/CountRankingCommand.php
+++ b/app/Console/Commands/CountRankingCommand.php
@@ -20,6 +20,7 @@ class CountRankingCommand extends Command
      */
     protected $description = 'Web整地ランキングのカウント用バッチ';
 
+    private $rankings;
     /**
      * Create a new command instance.
      *
@@ -28,6 +29,12 @@ class CountRankingCommand extends Command
     public function __construct()
     {
         parent::__construct();
+        $this->rankings = [
+            "break" => new CountDailyRanking(),
+            "build" => new CountWeeklyRanking(),
+            "playtime" => new CountMonthlyRanking(),
+            "vote" => new CountYearlyRanking()
+        ];
     }
 
     /**
@@ -37,21 +44,6 @@ class CountRankingCommand extends Command
     public function handle()
     {
         $type = $this->argument('type');
-
-        switch ($type) {
-            case 'daily':
-                (new CountDailyRanking())->handle();
-                break;
-            case 'weekly':
-                (new CountWeeklyRanking())->handle();
-                break;
-            case 'monthly':
-                (new CountMonthlyRanking())->handle();
-                break;
-            case 'yearly':
-                (new CountYearlyRanking())->handle();
-                break;
-            default:
-        }
+        $this->rankings[$type]->handle();
     }
 }

--- a/app/Console/Commands/CountRankingCommand.php
+++ b/app/Console/Commands/CountRankingCommand.php
@@ -11,14 +11,14 @@ class CountRankingCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'ranking:count {type=daily : 期間を指定}';
+    protected $signature = 'ranking:count {type=all : カウントするランキング}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Web整地ランキングのカウント用バッチ';
+    protected $description = 'Web整地ランキングの用バッチ';
 
     private $rankings;
     /**
@@ -44,6 +44,14 @@ class CountRankingCommand extends Command
     public function handle()
     {
         $type = $this->argument('type');
-        $this->rankings[$type]->handle();
+        switch ($type){
+            case "all":
+                foreach ($this->rankings as $ranking) {
+                    $ranking->handle();
+                }
+                break;
+            default:
+                $this->rankings[$type]->handle();
+        }
     }
 }

--- a/app/Console/Commands/CountRankingCommand.php
+++ b/app/Console/Commands/CountRankingCommand.php
@@ -30,10 +30,10 @@ class CountRankingCommand extends Command
     {
         parent::__construct();
         $this->rankings = [
-            "break" => new CountDailyRanking(),
-            "build" => new CountWeeklyRanking(),
-            "playtime" => new CountMonthlyRanking(),
-            "vote" => new CountYearlyRanking()
+            "daily" => new CountDailyRanking(),
+            "weekly" => new CountWeeklyRanking(),
+            "monthly" => new CountMonthlyRanking(),
+            "yearly" => new CountYearlyRanking()
         ];
     }
 

--- a/app/Console/Commands/CountRankingCommand.php
+++ b/app/Console/Commands/CountRankingCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class CountRankingCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'ranking:count {type=daily : 期間を指定}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Web整地ランキングのカウント用バッチ';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     */
+    public function handle()
+    {
+        $type = $this->argument('type');
+
+        switch ($type) {
+            case 'daily':
+                (new CountDailyRanking())->handle();
+                break;
+            case 'weekly':
+                (new CountWeeklyRanking())->handle();
+                break;
+            case 'monthly':
+                (new CountMonthlyRanking())->handle();
+                break;
+            case 'yearly':
+                (new CountYearlyRanking())->handle();
+                break;
+            default:
+        }
+    }
+}

--- a/app/Console/Commands/CountWeeklyRanking.php
+++ b/app/Console/Commands/CountWeeklyRanking.php
@@ -1,0 +1,75 @@
+<?php
+
+
+namespace App\Console\Commands;
+
+use App\WeeklyRankingTable;
+use App\PlayerData;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+
+class CountWeeklyRanking extends Command
+{
+    /**
+     * Execute the console command.
+     *
+     */
+    public function handle()
+    {
+        logger('>>>>  ウィークリーランキングバッチ：処理開始 >>>>');
+
+        Carbon::setWeekStartsAt(Carbon::SUNDAY);
+        Carbon::setWeekEndsAt(Carbon::SATURDAY);
+        // 今週ログインしたユーザのデータを取得する
+        $target_data = PlayerData::wherebetween('lastquit', [Carbon::now()->startOfWeek(), Carbon::now()->endOfWeek()])->get();
+        logger('処理対象件数：' . count($target_data));
+        $this->countRanking($target_data);
+
+        logger('<<<<  ウィークリーランキングバッチ：処理終了 <<<<');
+    }
+
+    /**
+     * ランキングデータのカウント＋保存
+     * @param $target_data
+     */
+    private function countRanking($target_data)
+    {
+        foreach ($target_data as $player_data) {
+            // カウント用テーブルのデータ有無を確認
+            Carbon::setWeekStartsAt(Carbon::SUNDAY);
+            Carbon::setWeekEndsAt(Carbon::SATURDAY);
+
+            $today_data = WeeklyRankingTable::where('uuid', $player_data->uuid)
+                ->wherebetween('count_date', [Carbon::now()->startOfWeek(), Carbon::now()->endOfWeek()])->first();
+
+            if (empty($today_data)) {
+                // カウント用テーブルに比較用の初期データを登録
+                $weekly_ranking_table = new WeeklyRankingTable();
+                $weekly_ranking_table->count_date = Carbon::now();   // datetime
+                $weekly_ranking_table->name = $player_data->name;    // varchar(30)
+                $weekly_ranking_table->uuid = $player_data->uuid;    // varchar(128)
+                $weekly_ranking_table->previous_break_count = $player_data->totalbreaknum;   // bigint(20)
+                $weekly_ranking_table->previous_build_count = $player_data->build_count;     // int(11)
+                $weekly_ranking_table->previous_vote_count = $player_data->p_vote;           // int(11)
+                $weekly_ranking_table->previous_playtick_count = $player_data->playtick;     // int(11)
+                $weekly_ranking_table->save();
+            } else {
+                // 整地量
+                $diff_break = $player_data->totalbreaknum - $today_data->previous_break_count;
+                $today_data->break_count= $diff_break;
+
+                // 建築量
+                $diff_build = $player_data->build_count - $today_data->previous_build_count;
+                $today_data->build_count= $diff_build;
+
+                $diff_tick = $player_data->playtick - $today_data->previous_playtick_count;
+                $today_data->playtick_count = $diff_tick;
+
+                // 投票数
+                $today_data->vote_count= $player_data->p_vote;
+
+                $today_data->save();
+            }
+        }
+    }
+}

--- a/app/Console/Commands/CountWeeklyRanking.php
+++ b/app/Console/Commands/CountWeeklyRanking.php
@@ -16,7 +16,7 @@ class CountWeeklyRanking extends CountRanking
     {
         logger('>>>>  ウィークリーランキングバッチ：処理開始 >>>>');
 
-        // 24時間以内にログインしたユーザのデータを取得する
+        // 24時間以内にログインしたユーザを更新対象にする
         $target_data = PlayerData::where('lastquit', '>', Carbon::yesterday())->get();
         logger('処理対象件数：' . count($target_data));
         $this->countRanking($target_data);
@@ -31,19 +31,19 @@ class CountWeeklyRanking extends CountRanking
     private function countRanking($target_data)
     {
         foreach ($target_data as $player_data) {
+            Carbon::setWeekStartsAt(Carbon::SUNDAY);    // 週の始まりの曜日設定
+            Carbon::setWeekEndsAt(Carbon::SATURDAY);    // 週の終わりの曜日設定
+            // Carbon::now()->startOfWeek()で週の始まりの年月日を取得
             // カウント用テーブルのデータ有無を確認
-            Carbon::setWeekStartsAt(Carbon::SUNDAY);
-            Carbon::setWeekEndsAt(Carbon::SATURDAY);
-
             $week_data = WeeklyRankingTable::where('uuid', $player_data->uuid)
                 ->wherebetween('count_date', [Carbon::now()->startOfWeek(), Carbon::now()->endOfWeek()])->first();
 
             if (empty($week_data)) {
                 // カウント用テーブルに比較用の初期データを登録
-                $weekly_ranking_table = new WeeklyRankingTable();
-                parent::savePreviousData($weekly_ranking_table, $player_data);
+                parent::registerInitialData(new WeeklyRankingTable(), $player_data);
             } else {
-                parent::saveDiffData($week_data, $player_data);
+                // 初期データとの差分を記録
+                parent::registerDiffData($week_data, $player_data);
             }
         }
     }

--- a/app/Console/Commands/CountWeeklyRanking.php
+++ b/app/Console/Commands/CountWeeklyRanking.php
@@ -1,14 +1,12 @@
 <?php
 
-
 namespace App\Console\Commands;
 
 use App\WeeklyRankingTable;
 use App\PlayerData;
 use Carbon\Carbon;
-use Illuminate\Console\Command;
 
-class CountWeeklyRanking extends Command
+class CountWeeklyRanking
 {
     /**
      * Execute the console command.

--- a/app/Console/Commands/CountWeeklyRanking.php
+++ b/app/Console/Commands/CountWeeklyRanking.php
@@ -18,10 +18,8 @@ class CountWeeklyRanking extends Command
     {
         logger('>>>>  ウィークリーランキングバッチ：処理開始 >>>>');
 
-        Carbon::setWeekStartsAt(Carbon::SUNDAY);
-        Carbon::setWeekEndsAt(Carbon::SATURDAY);
-        // 今週ログインしたユーザのデータを取得する
-        $target_data = PlayerData::wherebetween('lastquit', [Carbon::now()->startOfWeek(), Carbon::now()->endOfWeek()])->get();
+        // 24時間以内にログインしたユーザのデータを取得する
+        $target_data = PlayerData::where('lastquit', '>', Carbon::yesterday())->get();
         logger('処理対象件数：' . count($target_data));
         $this->countRanking($target_data);
 

--- a/app/Console/Commands/CountWeeklyRanking.php
+++ b/app/Console/Commands/CountWeeklyRanking.php
@@ -6,7 +6,7 @@ use App\WeeklyRankingTable;
 use App\PlayerData;
 use Carbon\Carbon;
 
-class CountWeeklyRanking
+class CountWeeklyRanking extends CountRanking
 {
     /**
      * Execute the console command.
@@ -41,30 +41,9 @@ class CountWeeklyRanking
             if (empty($week_data)) {
                 // カウント用テーブルに比較用の初期データを登録
                 $weekly_ranking_table = new WeeklyRankingTable();
-                $weekly_ranking_table->count_date = Carbon::now();   // datetime
-                $weekly_ranking_table->name = $player_data->name;    // varchar(30)
-                $weekly_ranking_table->uuid = $player_data->uuid;    // varchar(128)
-                $weekly_ranking_table->previous_break_count = $player_data->totalbreaknum;   // bigint(20)
-                $weekly_ranking_table->previous_build_count = $player_data->build_count;     // int(11)
-                $weekly_ranking_table->previous_vote_count = $player_data->p_vote;           // int(11)
-                $weekly_ranking_table->previous_playtick_count = $player_data->playtick;     // int(11)
-                $weekly_ranking_table->save();
+                parent::savePreviousData($weekly_ranking_table, $player_data);
             } else {
-                // 整地量
-                $diff_break = $player_data->totalbreaknum - $week_data->previous_break_count;
-                $week_data->break_count= $diff_break;
-
-                // 建築量
-                $diff_build = $player_data->build_count - $week_data->previous_build_count;
-                $week_data->build_count= $diff_build;
-
-                $diff_tick = $player_data->playtick - $week_data->previous_playtick_count;
-                $week_data->playtick_count = $diff_tick;
-
-                // 投票数
-                $week_data->vote_count= $player_data->p_vote;
-
-                $week_data->save();
+                parent::saveDiffData($week_data, $player_data);
             }
         }
     }

--- a/app/Console/Commands/CountWeeklyRanking.php
+++ b/app/Console/Commands/CountWeeklyRanking.php
@@ -31,16 +31,22 @@ class CountWeeklyRanking extends CountRanking
     private function countRanking($target_data)
     {
         foreach ($target_data as $player_data) {
+            // カウント用テーブルのデータ有無を確認
+            $player = WeeklyRankingTable::where('uuid', $player_data->uuid)->first();
+
             Carbon::setWeekStartsAt(Carbon::SUNDAY);    // 週の始まりの曜日設定
             Carbon::setWeekEndsAt(Carbon::SATURDAY);    // 週の終わりの曜日設定
             // Carbon::now()->startOfWeek()で週の始まりの年月日を取得
-            // カウント用テーブルのデータ有無を確認
+            // 期間内のデータが存在するかを確認
             $week_data = WeeklyRankingTable::where('uuid', $player_data->uuid)
                 ->wherebetween('count_date', [Carbon::now()->startOfWeek(), Carbon::now()->endOfWeek()])->first();
 
-            if (empty($week_data)) {
+            if (empty($player)) {
                 // カウント用テーブルに比較用の初期データを登録
                 parent::registerInitialData(new WeeklyRankingTable(), $player_data);
+            } else if (empty($week_data)){
+                // 比較用の初期データを更新
+                parent::registerInitialData($player, $player_data);
             } else {
                 // 初期データとの差分を記録
                 parent::registerDiffData($week_data, $player_data);

--- a/app/Console/Commands/CountWeeklyRanking.php
+++ b/app/Console/Commands/CountWeeklyRanking.php
@@ -37,10 +37,10 @@ class CountWeeklyRanking extends Command
             Carbon::setWeekStartsAt(Carbon::SUNDAY);
             Carbon::setWeekEndsAt(Carbon::SATURDAY);
 
-            $today_data = WeeklyRankingTable::where('uuid', $player_data->uuid)
+            $week_data = WeeklyRankingTable::where('uuid', $player_data->uuid)
                 ->wherebetween('count_date', [Carbon::now()->startOfWeek(), Carbon::now()->endOfWeek()])->first();
 
-            if (empty($today_data)) {
+            if (empty($week_data)) {
                 // カウント用テーブルに比較用の初期データを登録
                 $weekly_ranking_table = new WeeklyRankingTable();
                 $weekly_ranking_table->count_date = Carbon::now();   // datetime
@@ -53,20 +53,20 @@ class CountWeeklyRanking extends Command
                 $weekly_ranking_table->save();
             } else {
                 // 整地量
-                $diff_break = $player_data->totalbreaknum - $today_data->previous_break_count;
-                $today_data->break_count= $diff_break;
+                $diff_break = $player_data->totalbreaknum - $week_data->previous_break_count;
+                $week_data->break_count= $diff_break;
 
                 // 建築量
-                $diff_build = $player_data->build_count - $today_data->previous_build_count;
-                $today_data->build_count= $diff_build;
+                $diff_build = $player_data->build_count - $week_data->previous_build_count;
+                $week_data->build_count= $diff_build;
 
-                $diff_tick = $player_data->playtick - $today_data->previous_playtick_count;
-                $today_data->playtick_count = $diff_tick;
+                $diff_tick = $player_data->playtick - $week_data->previous_playtick_count;
+                $week_data->playtick_count = $diff_tick;
 
                 // 投票数
-                $today_data->vote_count= $player_data->p_vote;
+                $week_data->vote_count= $player_data->p_vote;
 
-                $today_data->save();
+                $week_data->save();
             }
         }
     }

--- a/app/Console/Commands/CountYearlyRanking.php
+++ b/app/Console/Commands/CountYearlyRanking.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\YearlyRankingTable;
+use App\PlayerData;
+use Carbon\Carbon;
+
+class CountYearlyRanking
+{
+    /**
+     * Execute the console command.
+     *
+     */
+    public function handle()
+    {
+        logger('>>>>  イヤリーランキングバッチ：処理開始 >>>>');
+
+        // 24時間以内にログインしたユーザのデータを取得する
+        $target_data = PlayerData::where('lastquit', '>', Carbon::yesterday())->get();
+        logger('処理対象件数：'.count($target_data));
+        $this->countRanking($target_data);
+
+        logger('<<<<  イヤリーランキングバッチ：処理終了 <<<<');
+    }
+
+    /**
+     * ランキングデータのカウント＋保存
+     * @param $target_data
+     */
+    private function countRanking($target_data)
+    {
+        foreach ($target_data as $player_data) {
+            // カウント用テーブルのデータ有無を確認
+            $year_data = YearlyRankingTable::where('uuid', $player_data->uuid)
+                ->whereyear('count_date', Carbon::now()->year)->first();
+
+            if (empty($year_data)) {
+                // カウント用テーブルに比較用の初期データを登録
+                $yearly_ranking_table = new YearlyRankingTable();
+                $yearly_ranking_table->count_date = Carbon::now();   // datetime
+                $yearly_ranking_table->name = $player_data->name;    // varchar(30)
+                $yearly_ranking_table->uuid = $player_data->uuid;    // varchar(128)
+                $yearly_ranking_table->previous_break_count = $player_data->totalbreaknum;   // bigint(20)
+                $yearly_ranking_table->previous_build_count = $player_data->build_count;     // int(11)
+                $yearly_ranking_table->previous_vote_count = $player_data->p_vote;           // int(11)
+                $yearly_ranking_table->previous_playtick_count = $player_data->playtick;     // int(11)
+                $yearly_ranking_table->save();
+            } else {
+                // 整地量
+                $diff_break = $player_data->totalbreaknum - $year_data->previous_break_count;
+                $year_data->break_count= $diff_break;
+
+                // 建築量
+                $diff_build = $player_data->build_count - $year_data->previous_build_count;
+                $year_data->build_count= $diff_build;
+
+                $diff_tick = $player_data->playtick - $year_data->previous_playtick_count;
+                $year_data->playtick_count = $diff_tick;
+
+                // 投票数
+                $year_data->vote_count= $player_data->p_vote;
+
+                $year_data->save();
+            }
+        }
+    }
+}

--- a/app/Console/Commands/CountYearlyRanking.php
+++ b/app/Console/Commands/CountYearlyRanking.php
@@ -32,12 +32,17 @@ class CountYearlyRanking extends CountRanking
     {
         foreach ($target_data as $player_data) {
             // カウント用テーブルのデータ有無を確認
+            $player = YearlyRankingTable::where('uuid', $player_data->uuid)->first();
+            // 期間内のデータが存在するかを確認
             $year_data = YearlyRankingTable::where('uuid', $player_data->uuid)
                 ->whereyear('count_date', Carbon::now()->year)->first();
 
-            if (empty($year_data)) {
+            if (empty($player)) {
                 // カウント用テーブルに比較用の初期データを登録
                 parent::registerInitialData(new YearlyRankingTable(), $player_data);
+            } else if (empty($year_data)){
+                // 比較用の初期データを更新
+                parent::registerInitialData($player, $player_data);
             } else {
                 // 初期データとの差分を記録
                 parent::registerDiffData($year_data, $player_data);

--- a/app/Console/Commands/CountYearlyRanking.php
+++ b/app/Console/Commands/CountYearlyRanking.php
@@ -16,7 +16,7 @@ class CountYearlyRanking extends CountRanking
     {
         logger('>>>>  イヤリーランキングバッチ：処理開始 >>>>');
 
-        // 24時間以内にログインしたユーザのデータを取得する
+        // 24時間以内にログインしたユーザを更新対象にする
         $target_data = PlayerData::where('lastquit', '>', Carbon::yesterday())->get();
         logger('処理対象件数：'.count($target_data));
         $this->countRanking($target_data);
@@ -37,10 +37,10 @@ class CountYearlyRanking extends CountRanking
 
             if (empty($year_data)) {
                 // カウント用テーブルに比較用の初期データを登録
-                $yearly_ranking_table = new YearlyRankingTable();
-                parent::savePreviousData($yearly_ranking_table, $player_data);
+                parent::registerInitialData(new YearlyRankingTable(), $player_data);
             } else {
-                parent::saveDiffData($year_data, $player_data);
+                // 初期データとの差分を記録
+                parent::registerDiffData($year_data, $player_data);
             }
         }
     }

--- a/app/Console/Commands/CountYearlyRanking.php
+++ b/app/Console/Commands/CountYearlyRanking.php
@@ -6,7 +6,7 @@ use App\YearlyRankingTable;
 use App\PlayerData;
 use Carbon\Carbon;
 
-class CountYearlyRanking
+class CountYearlyRanking extends CountRanking
 {
     /**
      * Execute the console command.
@@ -38,30 +38,9 @@ class CountYearlyRanking
             if (empty($year_data)) {
                 // カウント用テーブルに比較用の初期データを登録
                 $yearly_ranking_table = new YearlyRankingTable();
-                $yearly_ranking_table->count_date = Carbon::now();   // datetime
-                $yearly_ranking_table->name = $player_data->name;    // varchar(30)
-                $yearly_ranking_table->uuid = $player_data->uuid;    // varchar(128)
-                $yearly_ranking_table->previous_break_count = $player_data->totalbreaknum;   // bigint(20)
-                $yearly_ranking_table->previous_build_count = $player_data->build_count;     // int(11)
-                $yearly_ranking_table->previous_vote_count = $player_data->p_vote;           // int(11)
-                $yearly_ranking_table->previous_playtick_count = $player_data->playtick;     // int(11)
-                $yearly_ranking_table->save();
+                parent::savePreviousData($yearly_ranking_table, $player_data);
             } else {
-                // 整地量
-                $diff_break = $player_data->totalbreaknum - $year_data->previous_break_count;
-                $year_data->break_count= $diff_break;
-
-                // 建築量
-                $diff_build = $player_data->build_count - $year_data->previous_build_count;
-                $year_data->build_count= $diff_build;
-
-                $diff_tick = $player_data->playtick - $year_data->previous_playtick_count;
-                $year_data->playtick_count = $diff_tick;
-
-                // 投票数
-                $year_data->vote_count= $player_data->p_vote;
-
-                $year_data->save();
+                parent::saveDiffData($year_data, $player_data);
             }
         }
     }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -13,7 +13,7 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        Commands\CountRanking::class,
+        Commands\CountRankingCommand::class,
     ];
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -13,7 +13,7 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        Commands\CountDailyRanking::class
+        Commands\CountRanking::class,
     ];
 
     /**

--- a/app/Http/Models/Api/PlayerRanking/BreakRankingResolver.php
+++ b/app/Http/Models/Api/PlayerRanking/BreakRankingResolver.php
@@ -8,7 +8,10 @@ class BreakRankingResolver extends RankingResolver
     const TOTAL_COMPARE_TARGET = 'totalbreaknum';
 
     const DAILY_TABLE_TARGET = 'daily_ranking_table';
-    const DAILY_COMPARE_TARGET = 'break_count';
+    const WEEKLY_TABLE_TARGET = 'weekly_ranking_table';
+    const MONTHLY_TABLE_TARGET = 'monthly_ranking_table';
+
+    const COMPARE_TARGET = 'break_count';
 
     const RANKING_TYPE = 'break';
 
@@ -18,12 +21,16 @@ class BreakRankingResolver extends RankingResolver
      */
     function getRankTable()
     {
-        if (request('duration') === 'daily') {
-            // デイリー
-            return self::DAILY_TABLE_TARGET;
-        } else {
-            // 総合
-            return self::TOTAL_TABLE_TARGET;
+        switch (request('duration'))
+        {
+            case 'daily':
+                return self::DAILY_TABLE_TARGET;
+            case 'weekly':
+                return self::WEEKLY_TABLE_TARGET;
+            case 'monthly':
+                return self::MONTHLY_TABLE_TARGET;
+            default:
+                return self::TOTAL_TABLE_TARGET;
         }
     }
 
@@ -33,12 +40,12 @@ class BreakRankingResolver extends RankingResolver
      */
     function getRankComparator()
     {
-        if (request('duration') === 'daily') {
-            // デイリー
-            return self::DAILY_COMPARE_TARGET;
-        } else {
+        if (request('duration') === 'total') {
             // 総合
             return self::TOTAL_COMPARE_TARGET;
+        } else {
+            // 総合以外
+            return self::COMPARE_TARGET;
         }
     }
 

--- a/app/Http/Models/Api/PlayerRanking/BreakRankingResolver.php
+++ b/app/Http/Models/Api/PlayerRanking/BreakRankingResolver.php
@@ -10,6 +10,7 @@ class BreakRankingResolver extends RankingResolver
     const DAILY_TABLE_TARGET = 'daily_ranking_table';
     const WEEKLY_TABLE_TARGET = 'weekly_ranking_table';
     const MONTHLY_TABLE_TARGET = 'monthly_ranking_table';
+    const YEARLY_TABLE_TARGET = 'yearly_ranking_table';
 
     const COMPARE_TARGET = 'break_count';
 
@@ -29,6 +30,8 @@ class BreakRankingResolver extends RankingResolver
                 return self::WEEKLY_TABLE_TARGET;
             case 'monthly':
                 return self::MONTHLY_TABLE_TARGET;
+            case 'yearly':
+                return self::YEARLY_TABLE_TARGET;
             default:
                 return self::TOTAL_TABLE_TARGET;
         }

--- a/app/Http/Models/Api/PlayerRanking/BuildRankingResolver.php
+++ b/app/Http/Models/Api/PlayerRanking/BuildRankingResolver.php
@@ -5,10 +5,12 @@ namespace App\Http\Models\Api\PlayerRanking;
 class BuildRankingResolver extends RankingResolver
 {
     const TOTAL_TABLE_TARGET = 'playerdata';
-    const TOTAL_COMPARE_TARGET = 'build_count';
 
     const DAILY_TABLE_TARGET = 'daily_ranking_table';
-    const DAILY_COMPARE_TARGET = 'build_count';
+    const WEEKLY_TABLE_TARGET = 'weekly_ranking_table';
+    const MONTHLY_TABLE_TARGET = 'monthly_ranking_table';
+
+    const COMPARE_TARGET = 'build_count';
 
     const RANKING_TYPE = 'build';
 
@@ -18,12 +20,16 @@ class BuildRankingResolver extends RankingResolver
      */
     function getRankTable()
     {
-        if (request('duration') === 'daily') {
-            // デイリー
-            return self::DAILY_TABLE_TARGET;
-        } else {
-            // 総合
-            return self::TOTAL_TABLE_TARGET;
+        switch (request('duration'))
+        {
+            case 'daily':
+                return self::DAILY_TABLE_TARGET;
+            case 'weekly':
+                return self::WEEKLY_TABLE_TARGET;
+            case 'monthly':
+                return self::MONTHLY_TABLE_TARGET;
+            default:
+                return self::TOTAL_TABLE_TARGET;
         }
     }
 
@@ -33,13 +39,7 @@ class BuildRankingResolver extends RankingResolver
      */
     function getRankComparator()
     {
-        if (request('duration') === 'daily') {
-            // デイリー
-            return self::DAILY_COMPARE_TARGET;
-        } else {
-            // 総合
-            return self::TOTAL_COMPARE_TARGET;
-        }
+        return self::COMPARE_TARGET;
     }
 
     function getRankingType()

--- a/app/Http/Models/Api/PlayerRanking/BuildRankingResolver.php
+++ b/app/Http/Models/Api/PlayerRanking/BuildRankingResolver.php
@@ -9,6 +9,7 @@ class BuildRankingResolver extends RankingResolver
     const DAILY_TABLE_TARGET = 'daily_ranking_table';
     const WEEKLY_TABLE_TARGET = 'weekly_ranking_table';
     const MONTHLY_TABLE_TARGET = 'monthly_ranking_table';
+    const YEARLY_TABLE_TARGET = 'yearly_ranking_table';
 
     const COMPARE_TARGET = 'build_count';
 
@@ -28,6 +29,8 @@ class BuildRankingResolver extends RankingResolver
                 return self::WEEKLY_TABLE_TARGET;
             case 'monthly':
                 return self::MONTHLY_TABLE_TARGET;
+            case 'yearly':
+                return self::YEARLY_TABLE_TARGET;
             default:
                 return self::TOTAL_TABLE_TARGET;
         }

--- a/app/Http/Models/Api/PlayerRanking/PlaytimeRankingResolver.php
+++ b/app/Http/Models/Api/PlayerRanking/PlaytimeRankingResolver.php
@@ -8,7 +8,10 @@ class PlaytimeRankingResolver extends RankingResolver
     const TOTAL_COMPARE_TARGET = 'playtick';
 
     const DAILY_TABLE_TARGET = 'daily_ranking_table';
-    const DAILY_COMPARE_TARGET = 'playtick_count';  // TODO 実装わすれ
+    const WEEKLY_TABLE_TARGET = 'weekly_ranking_table';
+    const MONTHLY_TABLE_TARGET = 'monthly_ranking_table';
+
+    const COMPARE_TARGET = 'playtick_count';  // TODO 実装わすれ
 
     const RANKING_TYPE = 'playtime';
 
@@ -34,12 +37,16 @@ class PlaytimeRankingResolver extends RankingResolver
      */
     function getRankTable()
     {
-        if (request('duration') === 'daily') {
-            // デイリー
-            return self::DAILY_TABLE_TARGET;
-        } else {
-            // 総合
-            return self::TOTAL_TABLE_TARGET;
+        switch (request('duration'))
+        {
+            case 'daily':
+                return self::DAILY_TABLE_TARGET;
+            case 'weekly':
+                return self::WEEKLY_TABLE_TARGET;
+            case 'monthly':
+                return self::MONTHLY_TABLE_TARGET;
+            default:
+                return self::TOTAL_TABLE_TARGET;
         }
     }
 
@@ -49,12 +56,12 @@ class PlaytimeRankingResolver extends RankingResolver
      */
     function getRankComparator()
     {
-        if (request('duration') === 'daily') {
-            // デイリー
-            return self::DAILY_COMPARE_TARGET;
-        } else {
+        if (request('duration') === 'total') {
             // 総合
             return self::TOTAL_COMPARE_TARGET;
+        } else {
+            // 総合以外
+            return self::COMPARE_TARGET;
         }
     }
 

--- a/app/Http/Models/Api/PlayerRanking/PlaytimeRankingResolver.php
+++ b/app/Http/Models/Api/PlayerRanking/PlaytimeRankingResolver.php
@@ -10,8 +10,9 @@ class PlaytimeRankingResolver extends RankingResolver
     const DAILY_TABLE_TARGET = 'daily_ranking_table';
     const WEEKLY_TABLE_TARGET = 'weekly_ranking_table';
     const MONTHLY_TABLE_TARGET = 'monthly_ranking_table';
+    const YEARLY_TABLE_TARGET = 'yearly_ranking_table';
 
-    const COMPARE_TARGET = 'playtick_count';  // TODO 実装わすれ
+    const COMPARE_TARGET = 'playtick_count';
 
     const RANKING_TYPE = 'playtime';
 
@@ -45,6 +46,8 @@ class PlaytimeRankingResolver extends RankingResolver
                 return self::WEEKLY_TABLE_TARGET;
             case 'monthly':
                 return self::MONTHLY_TABLE_TARGET;
+            case 'yearly':
+                return self::YEARLY_TABLE_TARGET;
             default:
                 return self::TOTAL_TABLE_TARGET;
         }

--- a/app/Http/Models/Api/PlayerRanking/RankingResolver.php
+++ b/app/Http/Models/Api/PlayerRanking/RankingResolver.php
@@ -60,8 +60,7 @@ abstract class RankingResolver
         // デイリーランキングの場合
 
             // 最終ログイン日時を取得
-        switch ($table)
-        {
+        switch ($table) {
             case 'daily_ranking_table':
                 $sql = <<<EOT
 (SELECT $comparator, @rank AS rank, cnt, @rank := @rank + cnt FROM (SELECT @rank := 1) AS Dummy,
@@ -116,8 +115,7 @@ EOT;
             // 最終ログイン日時を取得
             $query->leftJoin('playerdata', DB::raw('playerdata.uuid collate utf8_general_ci'), '=', "$table.uuid");
 
-            switch ($table)
-            {
+            switch ($table) {
                 case 'daily_ranking_table':
                     $query->where("$table.count_date", date('Y-m-d'));
                     break;
@@ -200,8 +198,6 @@ EOT;
                 $query->whereYear("$table.count_date", Carbon::now()->year);
                 break;
         }
-
-
         return $query->count();
     }
 }

--- a/app/Http/Models/Api/PlayerRanking/RankingResolver.php
+++ b/app/Http/Models/Api/PlayerRanking/RankingResolver.php
@@ -127,6 +127,7 @@ EOT;
                     $query->wherebetween("$table.count_date", [Carbon::now()->startOfWeek(), Carbon::now()->endOfWeek()]);
                     break;
                 case 'monthly_ranking_table':
+                    $query->whereYear("$table.count_date", Carbon::now()->year);
                     $query->whereMonth("$table.count_date", Carbon::now()->month);
                     break;
                 case 'yearly_ranking_table':
@@ -192,6 +193,7 @@ EOT;
                 $query->wherebetween("$table.count_date", [Carbon::now()->startOfWeek(), Carbon::now()->endOfWeek()]);
                 break;
             case 'monthly_ranking_table':
+                $query->whereYear("$table.count_date", Carbon::now()->year);
                 $query->whereMonth("$table.count_date", Carbon::now()->month);
                 break;
             case 'yearly_ranking_table':

--- a/app/Http/Models/Api/PlayerRanking/VoteRankingResolver.php
+++ b/app/Http/Models/Api/PlayerRanking/VoteRankingResolver.php
@@ -10,6 +10,7 @@ class VoteRankingResolver extends RankingResolver
     const DAILY_TABLE_TARGET = 'daily_ranking_table';
     const WEEKLY_TABLE_TARGET = 'weekly_ranking_table';
     const MONTHLY_TABLE_TARGET = 'monthly_ranking_table';
+    const YEARLY_TABLE_TARGET = 'yearly_ranking_table';
 
     const COMPARE_TARGET = 'vote_count';
 
@@ -29,6 +30,8 @@ class VoteRankingResolver extends RankingResolver
                 return self::WEEKLY_TABLE_TARGET;
             case 'monthly':
                 return self::MONTHLY_TABLE_TARGET;
+            case 'yearly':
+                return self::YEARLY_TABLE_TARGET;
             default:
                 return self::TOTAL_TABLE_TARGET;
         }

--- a/app/Http/Models/Api/PlayerRanking/VoteRankingResolver.php
+++ b/app/Http/Models/Api/PlayerRanking/VoteRankingResolver.php
@@ -4,13 +4,14 @@ namespace App\Http\Models\Api\PlayerRanking;
 
 class VoteRankingResolver extends RankingResolver
 {
-    const COMPARE_TARGET = 'p_vote';
-
     const TOTAL_TABLE_TARGET = 'playerdata';
     const TOTAL_COMPARE_TARGET = 'p_vote';
 
     const DAILY_TABLE_TARGET = 'daily_ranking_table';
-    const DAILY_COMPARE_TARGET = 'vote_count';
+    const WEEKLY_TABLE_TARGET = 'weekly_ranking_table';
+    const MONTHLY_TABLE_TARGET = 'monthly_ranking_table';
+
+    const COMPARE_TARGET = 'vote_count';
 
     const RANKING_TYPE = 'vote';
 
@@ -20,12 +21,16 @@ class VoteRankingResolver extends RankingResolver
      */
     function getRankTable()
     {
-        if (request('duration') === 'daily') {
-            // デイリー
-            return self::DAILY_TABLE_TARGET;
-        } else {
-            // 総合
-            return self::TOTAL_TABLE_TARGET;
+        switch (request('duration'))
+        {
+            case 'daily':
+                return self::DAILY_TABLE_TARGET;
+            case 'weekly':
+                return self::WEEKLY_TABLE_TARGET;
+            case 'monthly':
+                return self::MONTHLY_TABLE_TARGET;
+            default:
+                return self::TOTAL_TABLE_TARGET;
         }
     }
 
@@ -35,12 +40,12 @@ class VoteRankingResolver extends RankingResolver
      */
     function getRankComparator()
     {
-        if (request('duration') === 'daily') {
-            // デイリー
-            return self::DAILY_COMPARE_TARGET;
-        } else {
+        if (request('duration') === 'total') {
             // 総合
             return self::TOTAL_COMPARE_TARGET;
+        } else {
+            // 総合以外
+            return self::COMPARE_TARGET;
         }
 
     }

--- a/app/MonthlyRankingTable.php
+++ b/app/MonthlyRankingTable.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MonthlyRankingTable extends Model
+{
+    protected $table = 'monthly_ranking_table';
+}

--- a/app/WeeklyRankingTable.php
+++ b/app/WeeklyRankingTable.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class WeeklyRankingTable extends Model
+{
+    protected $table = 'weekly_ranking_table';
+}

--- a/app/YearlyRankingTable.php
+++ b/app/YearlyRankingTable.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class YearlyRankingTable extends Model
+{
+    protected $table = 'yearly_ranking_table';
+}

--- a/database/factories/MonthlyRankingTableFactory.php
+++ b/database/factories/MonthlyRankingTableFactory.php
@@ -1,0 +1,9 @@
+<?php
+
+use Faker\Generator as Faker;
+
+$factory->define(App\MonthlyRankingTable::class, function (Faker $faker) {
+    return [
+        //
+    ];
+});

--- a/database/factories/WeeklyRankingTableFactory.php
+++ b/database/factories/WeeklyRankingTableFactory.php
@@ -1,0 +1,9 @@
+<?php
+
+use Faker\Generator as Faker;
+
+$factory->define(App\WeeklyRankingTable::class, function (Faker $faker) {
+    return [
+        //
+    ];
+});

--- a/database/factories/YearlyRankingTableFactory.php
+++ b/database/factories/YearlyRankingTableFactory.php
@@ -1,0 +1,9 @@
+<?php
+
+use Faker\Generator as Faker;
+
+$factory->define(App\YearlyRankingTable::class, function (Faker $faker) {
+    return [
+        //
+    ];
+});

--- a/docker-lamp/files/sql/seichiassist.sql
+++ b/docker-lamp/files/sql/seichiassist.sql
@@ -99,3 +99,9 @@ CREATE TABLE `monthly_ranking_table` LIKE daily_ranking_table;
 
 INSERT INTO monthly_ranking_table (id, count_date, name, uuid, break_count, previous_break_count, updated_at, previous_build_count, previous_vote_count, created_at, previous_playtick_count )
 VALUES (1, NOW(), 'TestUser3', '000000003', 999, 11, NOW(), 777, 1, NOW(), 50);
+
+DROP TABLE IF EXISTS yearly_ranking_table;
+CREATE TABLE `yearly_ranking_table` LIKE daily_ranking_table;
+
+INSERT INTO yearly_ranking_table (id, count_date, name, uuid, break_count, previous_break_count, updated_at, previous_build_count, previous_vote_count, created_at, previous_playtick_count )
+VALUES (1, NOW(), 'TestUser4', '000000004', 999, 11, NOW(), 777, 1, NOW(), 50);

--- a/docker-lamp/files/sql/seichiassist.sql
+++ b/docker-lamp/files/sql/seichiassist.sql
@@ -64,5 +64,38 @@ CREATE TABLE `playerdata` (
  UNIQUE KEY `uuid` (`uuid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-INSERT INTO playerdata (name, uuid, totalbreaknum, build_count, p_vote)
-VALUES ("TestUser", "00000000", 999, 888, 777);
+INSERT INTO playerdata (name, uuid, totalbreaknum, lastquit, build_count, p_vote)
+VALUES ('TestUser1', '000000001', 999, NOW(), 888, 777);
+
+
+DROP TABLE IF EXISTS daily_ranking_table;
+CREATE TABLE `daily_ranking_table` (
+ `id` int(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+ `count_date` date NOT NULL,
+ `name` varchar(30) NOT NULL,
+ `uuid` varchar(128) NOT NULL,
+ `break_count` bigint(20) NOT NULL DEFAULT '0',
+ `build_count` bigint(20) NOT NULL DEFAULT '0',
+ `playtick_count` bigint(20) NOT NULL DEFAULT '0',
+ `vote_count` int(11) NOT NULL DEFAULT '0',
+ `previous_break_count` bigint(20) NOT NULL,
+ `previous_build_count` bigint(20) NOT NULL,
+ `previous_playtick_count` bigint(20) NOT NULL,
+ `previous_vote_count` int(11) NOT NULL,
+ `deleted_at` timestamp,
+ `created_at` datetime NOT NULL,
+ `updated_at` datetime NOT NULL,
+ UNIQUE KEY `id` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+INSERT INTO daily_ranking_table (id, count_date, name, uuid, break_count, playtick_count, previous_break_count, updated_at, previous_build_count, previous_vote_count, created_at, previous_playtick_count )
+VALUES (1, NOW(), 'test_user', '000000001', 999, 110, 11, NOW(), 777, 1, NOW(), 50);
+
+DROP TABLE IF EXISTS weekly_ranking_table;
+CREATE TABLE `weekly_ranking_table` LIKE daily_ranking_table;
+
+DROP TABLE IF EXISTS monthly_ranking_table;
+CREATE TABLE `monthly_ranking_table` LIKE daily_ranking_table;
+
+INSERT INTO monthly_ranking_table (id, count_date, name, uuid, break_count, previous_break_count, updated_at, previous_build_count, previous_vote_count, created_at, previous_playtick_count )
+VALUES (1, NOW(), 'TestUser3', '000000003', 999, 11, NOW(), 777, 1, NOW(), 50);

--- a/docker-lamp/files/sql/seichiassist.sql
+++ b/docker-lamp/files/sql/seichiassist.sql
@@ -82,7 +82,7 @@ CREATE TABLE `daily_ranking_table` (
  `previous_build_count` bigint(20) NOT NULL,
  `previous_playtick_count` bigint(20) NOT NULL,
  `previous_vote_count` int(11) NOT NULL,
- `deleted_at` timestamp,
+ `deleted_at` timestamp default NULL,
  `created_at` datetime NOT NULL,
  `updated_at` datetime NOT NULL,
  UNIQUE KEY `id` (`id`)

--- a/docker-lamp/files/sql/seichiassist.sql
+++ b/docker-lamp/files/sql/seichiassist.sql
@@ -82,7 +82,7 @@ CREATE TABLE `daily_ranking_table` (
  `previous_build_count` bigint(20) NOT NULL,
  `previous_playtick_count` bigint(20) NOT NULL,
  `previous_vote_count` int(11) NOT NULL,
- `deleted_at` timestamp default NULL,
+ `deleted_at` timestamp NULL DEFAULT NULL,
  `created_at` datetime NOT NULL,
  `updated_at` datetime NOT NULL,
  UNIQUE KEY `id` (`id`)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,7 +13,7 @@ const source = require('vinyl-source-stream');
 const buffer = require('vinyl-buffer');
 const uglify = require('gulp-uglify');
 
-gulp.task('browserify', () => {
+gulp.task('browserify', function(done)  {
     browserify('./resources/assets/jsx/ranking.jsx', { debug : false })
         .transform(babelify).bundle()
         .on('error', console.log)
@@ -29,6 +29,7 @@ gulp.task('browserify', () => {
         .pipe(buffer())
         .pipe(uglify())
         .pipe(gulp.dest('./public/js'));
+    done();
 });
 
-gulp.task("default", ['browserify']);
+gulp.task('default', gulp.task('browserify'));

--- a/package.json
+++ b/package.json
@@ -31,11 +31,13 @@
   "dependencies": {
     "babel-polyfill": "^6.26.0",
     "eventemitter2": "^4.1.2",
+    "gulp": "^4.0.2",
     "isomorphic-fetch": "^2.2.1",
     "laravel-elixir": "^6.0.0-15",
     "mobx": "^3.3.0",
     "mobx-react": "^4.3.2",
     "react": "^15.6.1",
-    "react-dom": "^15.6.1"
+    "react-dom": "^15.6.1",
+    "vinyl-source-stream": "^2.0.0"
   }
 }

--- a/resources/assets/jsx/components/ranking-body.jsx
+++ b/resources/assets/jsx/components/ranking-body.jsx
@@ -72,10 +72,6 @@ const WrappedPagination = observer(({ store }) =>
 );
 
 const RankingTable = observer(({ store }) => {
-    // TODO 期間ランキングのAPIが実装され次第このブロックを消すこと
-    if (store.duration === "weekly" || store.duration === "monthly" || store.duration === "yearly") {
-        return <div>※ 近日公開予定</div>;
-    }
 
     if (store.ranking === undefined) {
         return null;

--- a/tests/Unit/DailyRankingTest.php
+++ b/tests/Unit/DailyRankingTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Unit;
 
-use App\Console\Commands\CountDailyRanking;
+use App\Console\Commands\CountRanking;
 use App\DailyRankingTable;
 use App\PlayerData;
 use Tests\TestCase;
@@ -24,7 +24,7 @@ class DailyRankingTest extends TestCase
         logger($player_data);
 
         // バッチ実行①
-        $batch = new CountDailyRanking();
+        $batch = new CountRanking();
         $batch->handle();
 
         // 24時間以内にログインしていないため、ヒットしないこと

--- a/tests/Unit/DailyRankingTest.php
+++ b/tests/Unit/DailyRankingTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Unit;
 
-use App\Console\Commands\CountRanking;
+use App\Console\Commands\CountRankingCommand;
 use App\DailyRankingTable;
 use App\PlayerData;
 use Tests\TestCase;
@@ -24,7 +24,7 @@ class DailyRankingTest extends TestCase
         logger($player_data);
 
         // バッチ実行①
-        $batch = new CountRanking();
+        $batch = new CountRankingCommand();
         $batch->handle();
 
         // 24時間以内にログインしていないため、ヒットしないこと


### PR DESCRIPTION
以下のランキングを実装しました
- 週間ランキング
- 月間ランキング
- 年間ランキング
- 各種接続時間ランキング

新しく以下のテーブルが必要になります
構造は`daily_ranking_table`と同様のものです
- `weekly_ranking_table`
- `monthly_ranking_table`
- `yearly_ranking_table`

各種ランキングの更新は以下のコマンドで行えます
- `php artisan ranking:count` : すべてのランキングの更新
- `php artisan ranking:count all` : 同上
- `php artisan ranking:count daily` : 日間ランキング
- `php artisan ranking:count weekly` : 週間ランキング
- `php artisan ranking:count monthly` : 月間ランキング
- `php artisan ranking:count yearly` : 年間ランキング