### PR TITLE
プレイヤー検索APIで利用するカラム名の判定ロジックを修正

### DIFF
--- a/app/Http/Models/Api/PlayerRanking/BreakRankingResolver.php
+++ b/app/Http/Models/Api/PlayerRanking/BreakRankingResolver.php
@@ -43,7 +43,7 @@ class BreakRankingResolver extends RankingResolver
      */
     function getRankComparator()
     {
-        if (request('duration') === 'total') {
+        if (request('duration') === 'total' || blank(request('duration'))) {
             // 総合
             return self::TOTAL_COMPARE_TARGET;
         } else {

--- a/app/Http/Models/Api/PlayerRanking/PlaytimeRankingResolver.php
+++ b/app/Http/Models/Api/PlayerRanking/PlaytimeRankingResolver.php
@@ -59,7 +59,7 @@ class PlaytimeRankingResolver extends RankingResolver
      */
     function getRankComparator()
     {
-        if (request('duration') === 'total') {
+        if (request('duration') === 'total' || blank(request('duration'))) {
             // 総合
             return self::TOTAL_COMPARE_TARGET;
         } else {

--- a/app/Http/Models/Api/PlayerRanking/VoteRankingResolver.php
+++ b/app/Http/Models/Api/PlayerRanking/VoteRankingResolver.php
@@ -43,7 +43,7 @@ class VoteRankingResolver extends RankingResolver
      */
     function getRankComparator()
     {
-        if (request('duration') === 'total') {
+        if (request('duration') === 'total' || blank(request('duration'))) {
             // 総合
             return self::TOTAL_COMPARE_TARGET;
         } else {


### PR DESCRIPTION
APIリクエストの種別が指定されていない場合の「利用するカラム」の判定ロジックの修正
（プレイヤー検索APIは、各種ランキングの集計とは別のクエリを利用するため）