### PR TITLE
Fix broken avatar url

### DIFF
--- a/resources/assets/jsx/components/ranking-body.jsx
+++ b/resources/assets/jsx/components/ranking-body.jsx
@@ -35,7 +35,7 @@ const formatRankedData = (json_data, rankingType) => {
  * アバターのURLを取得する
  * @param playerName プレーヤー名
  */
-const getAvatarUrl = playerName => `https://avatar.minecraft.jp/${playerName}/minecraft//m.png`;
+const getAvatarUrl = playerName => `http://cravatar.eu/helmavatar/${playerName}.png`;
 
 const RankingItem = observer(({rank: rankObject}) => {
     const player = rankObject.player;


### PR DESCRIPTION
JMS経由でアバターのアイコンを取得していたが、機能していないため修正。参照：https://cravatar.eu/

Fixes #164.